### PR TITLE
Major import chain filtering Bug fix plus 3 new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ outputFile | Name of outputs | output | no
 searchOnly | Search existing DB without building/updating it | false | no
 threads | Number of threads to use for building DB | 5 | no
 singleThreadSearch | Use only 1 thread for searching | false | no
+searchTimeout | Time out in minutes before canceling search and lowering depth | 60 | no
+excludeTestDirs | Flag for excluding anything in a test directory when building DB | false | no
+depExclusions | Comma delimited list of regex used for excluding dependencies when building DB | empty | no
+
 
 ### Performance
 Database construction is fairly performant. Searches on the other hand will vary wildly depending on the size and structure of your application. So be mindful of the search depth setting and start conservatively. Increasing the search depth increases search time and memory usage exponentially.

--- a/src/main/java/com/jtmelton/tpl/cli/Cli.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Cli.java
@@ -50,17 +50,38 @@ public class Cli {
 
   @Argument(value ="threads",
       description = "Number of threads to use for graph construction. Defaults to 5")
-  private static int threads = 5;
+  private static Integer threads = 5;
 
   @Argument(value ="singleThreadSearch",
       description = "Use only one thread for search. Helps on memory usage. Default is 2 threads")
   private static boolean searchThreads = false;
 
+  @Argument(value = "searchTimeout",
+      description = "Search Timeout in minutes before killing thread and lowering depth. Default is 60 min")
+  private static Integer searchTimeout = 60;
+
+  @Argument(value = "excludeTestDirs",
+      description = "Excludes test dirs from relationship analysis")
+  private static boolean excludeTestDirs = false;
+
+  @Argument(value = "depExclusions",
+      description = "Comma delimited regex for excluding jar dependencies from analysis")
+  private static String[] depExclusions = new String[]{};
+
   public static void main(String[] args) {
     new Cli().parseArgs(args);
 
-    ThirdPartyLibraryAnalyzer analyzer =
-            new ThirdPartyLibraryAnalyzer(jarsDirectory, classesDirectory, dbDirectory, threads, searchThreads);
+    Options options = new Options();
+    options.setJarsDirectory(jarsDirectory);
+    options.setClassesDirectory(classesDirectory);
+    options.setDbDirectory(dbDirectory);
+    options.setThreads(threads);
+    options.setSingleThreadSearch(searchThreads);
+    options.setSearchTimeout(searchTimeout);
+    options.setExcludeTestDirs(excludeTestDirs);
+    Arrays.asList(depExclusions).forEach(options::addDepExclusion);
+
+    ThirdPartyLibraryAnalyzer analyzer = new ThirdPartyLibraryAnalyzer(options);
 
     try {
       if(!searchOnly) {

--- a/src/main/java/com/jtmelton/tpl/cli/Options.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Options.java
@@ -1,0 +1,88 @@
+package com.jtmelton.tpl.cli;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class Options {
+
+  private boolean singleThreadSearch;
+
+  private String jarsDirectory;
+
+  private String classesDirectory;
+
+  private String dbDirectory;
+
+  private int threads;
+
+  private int searchTimeout;
+
+  private boolean excludeTestDirs = true;
+
+  private Collection<String> depExclusions = new ArrayList<>();
+
+  public boolean isSingleThreadSearch() {
+    return singleThreadSearch;
+  }
+
+  public void setSingleThreadSearch(boolean singleThreadSearch) {
+    this.singleThreadSearch = singleThreadSearch;
+  }
+
+  public String getJarsDirectory() {
+    return jarsDirectory;
+  }
+
+  public void setJarsDirectory(String jarsDirectory) {
+    this.jarsDirectory = jarsDirectory;
+  }
+
+  public String getClassesDirectory() {
+    return classesDirectory;
+  }
+
+  public void setClassesDirectory(String classesDirectory) {
+    this.classesDirectory = classesDirectory;
+  }
+
+  public String getDbDirectory() {
+    return dbDirectory;
+  }
+
+  public void setDbDirectory(String dbDirectory) {
+    this.dbDirectory = dbDirectory;
+  }
+
+  public int getThreads() {
+    return threads;
+  }
+
+  public void setThreads(int threads) {
+    this.threads = threads;
+  }
+
+  public int getSearchTimeout() {
+    return searchTimeout;
+  }
+
+  public void setSearchTimeout(int searchTimeout) {
+    this.searchTimeout = searchTimeout;
+  }
+
+  public boolean isExcludeTestDirs() {
+    return excludeTestDirs;
+  }
+
+  public void setExcludeTestDirs(boolean excludeTestDirs) {
+    this.excludeTestDirs = excludeTestDirs;
+  }
+
+  public void addDepExclusion(String exclusion) {
+    depExclusions.add(exclusion);
+  }
+
+  public Collection<String> getDepExclusions() {
+    return Collections.unmodifiableCollection(depExclusions);
+  }
+}

--- a/src/main/java/com/jtmelton/tpl/results/ResultsProcessor.java
+++ b/src/main/java/com/jtmelton/tpl/results/ResultsProcessor.java
@@ -42,7 +42,7 @@ public class ResultsProcessor {
     for(List<Map<String, Object>> result : results.getClassChains()) {
       execChainEntryStart();
 
-      //Don't care about the last element which contains the matched jar
+      //Don't care about the first element which contains the matched jar
       for(int i = result.size() - 1;i > 0;i--) {
         String className = (String) result.get(i).get("name");
         long id = (Long) result.get(i).get("id");


### PR DESCRIPTION
There was a major bug that was fixed that caused incorrect filtering of import chains. The goal is to link a user class back to a jar. We don't necessarily care about all the permutations of how it links but rather just need to know that there is a link. As such we filter based on unique class file to a particular jar. The bug was not using the user class for filtering. This has been addressed.

Three new arguments have been added. Please reference the arguments section on the readme for info regarding the new arguments.
