### PR TITLE
Major threading bug fix

### DIFF
--- a/src/main/java/com/jtmelton/tpl/cli/Cli.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Cli.java
@@ -68,6 +68,10 @@ public class Cli {
       description = "Comma delimited regex for excluding jar dependencies from analysis")
   private static String[] depExclusions = new String[]{};
 
+  @Argument(value = "stdoutReporter",
+      description = "Enable stdout reporter. Has memory impact if you searches eat up a lot of memory")
+  private static boolean stdoutReporter = false;
+
   public static void main(String[] args) {
     new Cli().parseArgs(args);
 
@@ -96,7 +100,9 @@ public class Cli {
           LOG.warn("Failed to register reporters", ioe);
         }
 
-        analyzer.registerReporter(new StdOutReporter());
+        if(stdoutReporter) {
+          analyzer.registerReporter(new StdOutReporter());
+        }
 
         Collection<String> jarNamesList = Arrays.asList(jarNames);
         analyzer.reportAffectedClasses(jarNamesList, searchDepth, outputFile);


### PR DESCRIPTION
Threads that went over timeout would remain alive while new threads would be spun up, hammering resources.

Now utilizing the timeout feature built into neo4j when beginning a transaction.

Also jars with duplicate names are ignored in searches but added to results. Will switch to an identifying hash in the future as thats a more reliable way of identifying if a jar is in fact a dupe.