### PR TITLE
Visualizer scaling bug fix

### DIFF
--- a/src/main/resources/visualizer/graph/src/graph.js
+++ b/src/main/resources/visualizer/graph/src/graph.js
@@ -247,11 +247,12 @@ function mouseMovement() {
 }
 
 function mouseWheel(event) {
+    let oldScale = scaleFactor
     scaleFactor -= event.delta * 0.0005;
 
     if(scaleFactor > 0) {
-        translateX += event.delta * ((mouseX - translateX) / scaleFactor) * 0.0005;
-        translateY += event.delta * ((mouseY - translateY) / scaleFactor) * 0.0005;
+        translateX += event.delta * ((mouseX - translateX) / oldScale) * 0.0005;
+        translateY += event.delta * ((mouseY - translateY) / oldScale) * 0.0005;
     } else {
         scaleFactor = 0;
     }


### PR DESCRIPTION
Fixed bug where screen translation was being done on the newly computed scale factor rather than the current scale. This caused the translation being offset from where the mouse pointer started the scaling operation.