### PR TITLE
New unused jar search funtionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ TPLA contains a built in visualizer. It will emit a visualization folder contain
 ![Visualizer](visScreenShot.png)
 Top left is a list of jars present which are paginated. Top right lists stats. The view can be translated and zoomed. Indivdual nodes can be selected to highlight their connections. Selecting a node will highlight what jar it belongs to in the top left. Clicking on a colored square in the top left will translate view to that cluster of classes.
 
+### Unused Jars Search
+When using the -searchUnusedOnly argument, a query is run to determine what jars in the database are not referenced by a user class. The accuracy of the results will be based on the specified depth of the search. Like in the usage search, the higher the depth, the longer the query will take to complete. This search produces a text file in your output directory.
+
 ### Arguments
 Arg | Description | Default | Required
 ------------- | ------------- | --- | ---
@@ -95,6 +98,9 @@ singleThreadSearch | Use only 1 thread for searching | false | no
 searchTimeout | Time out in minutes before canceling search and lowering depth | 60 | no
 excludeTestDirs | Flag for excluding anything in a test directory when building DB | false | no
 depExclusions | Comma delimited list of regex used for excluding dependencies when building DB | empty | no
+searchUnusedOnly | Search for unused jars. Cannot be used in conjunction with searchOnly | false | no
+unusedJarExclusions | Comma delimited regex for excluding jars from unused jar search. Filters after inclusions | empty | no
+unusedJarInclusions | Comma delimited regex for specifying which jars to include in unused search. Filter before exclusions | empty | no
 
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ searchTimeout | Time out in minutes before canceling search and lowering depth |
 excludeTestDirs | Flag for excluding anything in a test directory when building DB | false | no
 depExclusions | Comma delimited list of regex used for excluding dependencies when building DB | empty | no
 searchUnusedOnly | Search for unused jars. Cannot be used in conjunction with searchOnly | false | no
-unusedJarExclusions | Comma delimited regex for excluding jars from unused jar search. Filters after inclusions | empty | no
-unusedJarInclusions | Comma delimited regex for specifying which jars to include in unused search. Filter before exclusions | empty | no
+searchJarExclusions | Comma delimited regex for excluding jars from used/unused jar searches. Filters after inclusions | empty | no
+searchJarInclusions | Comma delimited regex for specifying which jars to include in used/unused searches. Filter before exclusions | empty | no
+filterResults | Enable filtering on results so only one dependency chain from user class to jar is present per jar | false | no
 
 
 ### Performance

--- a/src/main/java/com/jtmelton/tpl/cli/Cli.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Cli.java
@@ -52,15 +52,15 @@ public class Cli {
       description = "Search for jars that are not potentially unused")
   private static boolean searchUnusedOnly = false;
 
-  @Argument(value = "unusedJarExclusions",
-      description = "Comma delimited regex for excluding jars from unused jar search. " +
+  @Argument(value = "searchJarExclusions",
+      description = "Comma delimited regex for excluding jars from search unused or used searches. " +
               "Inclusions filter first, then exclusions filter the returned subset")
-  private static String[] unusedJarExclusions = new String[]{};
+  private static String[] searchJarExclusions = new String[]{};
 
-  @Argument(value = "unusedJarInclusions",
-      description = "Comma delimited regex for which specific jars should be checked in unused jar search. " +
+  @Argument(value = "searchJarInclusions",
+      description = "Comma delimited regex for which specific jars should be checked unused or used searches. " +
               "Inclusions filter first, then exclusions filter the returned subset")
-  private static String[] unusedJarInclusions = new String[]{};
+  private static String[] searchJarInclusions = new String[]{};
 
   @Argument(value ="threads",
       description = "Number of threads to use for graph construction. Defaults to 5")
@@ -86,6 +86,10 @@ public class Cli {
       description = "Enable stdout reporter. Has memory impact if you searches eat up a lot of memory")
   private static boolean stdoutReporter = false;
 
+  @Argument(value = "filterResults",
+      description = "Enable filtering on results so only one dependency chain from user class to jar is present per jar")
+  private static boolean filterResults = false;
+
   public static void main(String[] args) {
     new Cli().parseArgs(args);
 
@@ -103,9 +107,10 @@ public class Cli {
     options.setSingleThreadSearch(searchThreads);
     options.setSearchTimeout(searchTimeout);
     options.setExcludeTestDirs(excludeTestDirs);
+    options.setFilterResults(filterResults);
     Arrays.asList(depExclusions).forEach(options::addDepExclusion);
-    Arrays.asList(unusedJarExclusions).forEach(options::addUnusedJarExclusion);
-    Arrays.asList(unusedJarInclusions).forEach(options::addUnusedJarInclusion);
+    Arrays.asList(searchJarExclusions).forEach(options::addSearchJarExclusion);
+    Arrays.asList(searchJarInclusions).forEach(options::addSearchJarInclusion);
 
     ThirdPartyLibraryAnalyzer analyzer = new ThirdPartyLibraryAnalyzer(options);
 

--- a/src/main/java/com/jtmelton/tpl/cli/Options.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Options.java
@@ -22,6 +22,10 @@ public class Options {
 
   private Collection<String> depExclusions = new ArrayList<>();
 
+  private Collection<String> unusedJarExclusions = new ArrayList<>();
+
+  private Collection<String> unusedJarInclusions = new ArrayList<>();
+
   public boolean isSingleThreadSearch() {
     return singleThreadSearch;
   }
@@ -82,7 +86,23 @@ public class Options {
     depExclusions.add(exclusion);
   }
 
+  public void addUnusedJarExclusion(String exclusion) {
+    unusedJarExclusions.add(exclusion);
+  }
+
+  public void addUnusedJarInclusion(String inclusion) {
+    unusedJarInclusions.add(inclusion);
+  }
+
   public Collection<String> getDepExclusions() {
     return Collections.unmodifiableCollection(depExclusions);
+  }
+
+  public Collection<String> getUnusedJarExclusions() {
+    return Collections.unmodifiableCollection(unusedJarExclusions);
+  }
+
+  public Collection<String> getUnusedJarInclusions() {
+    return Collections.unmodifiableCollection(unusedJarInclusions);
   }
 }

--- a/src/main/java/com/jtmelton/tpl/cli/Options.java
+++ b/src/main/java/com/jtmelton/tpl/cli/Options.java
@@ -20,11 +20,13 @@ public class Options {
 
   private boolean excludeTestDirs = true;
 
+  private boolean filterResults = false;
+
   private Collection<String> depExclusions = new ArrayList<>();
 
-  private Collection<String> unusedJarExclusions = new ArrayList<>();
+  private Collection<String> searchJarExclusions = new ArrayList<>();
 
-  private Collection<String> unusedJarInclusions = new ArrayList<>();
+  private Collection<String> searchJarInclusions = new ArrayList<>();
 
   public boolean isSingleThreadSearch() {
     return singleThreadSearch;
@@ -86,23 +88,31 @@ public class Options {
     depExclusions.add(exclusion);
   }
 
-  public void addUnusedJarExclusion(String exclusion) {
-    unusedJarExclusions.add(exclusion);
+  public void addSearchJarExclusion(String exclusion) {
+    searchJarExclusions.add(exclusion);
   }
 
-  public void addUnusedJarInclusion(String inclusion) {
-    unusedJarInclusions.add(inclusion);
+  public void addSearchJarInclusion(String inclusion) {
+    searchJarInclusions.add(inclusion);
   }
 
   public Collection<String> getDepExclusions() {
     return Collections.unmodifiableCollection(depExclusions);
   }
 
-  public Collection<String> getUnusedJarExclusions() {
-    return Collections.unmodifiableCollection(unusedJarExclusions);
+  public Collection<String> getSearchJarExclusions() {
+    return Collections.unmodifiableCollection(searchJarExclusions);
   }
 
-  public Collection<String> getUnusedJarInclusions() {
-    return Collections.unmodifiableCollection(unusedJarInclusions);
+  public Collection<String> getSearchJarInclusions() {
+    return Collections.unmodifiableCollection(searchJarInclusions);
+  }
+
+  public boolean isFilterResults() {
+    return filterResults;
+  }
+
+  public void setFilterResults(boolean filterResults) {
+    this.filterResults = filterResults;
   }
 }


### PR DESCRIPTION
- Can now search for unused jars using the searchUnusedOnly argument. The search is affected by depth argument.
- New filterResults argument. Th original release had the functionality as if this argument were present. You can decide if you want to see all the permutations of how a user class is linked to a jar or just a single one for evidence.
- Both user to jar and unused jar searches can be filtered via searchJarExclusions and searchJarInclusions arguments.

Readme is updated with more details regarding changes.